### PR TITLE
Add SHACL schema for registry metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains:
 - Source schema for Regen Network ontology (TODO)
 - [SHACL](https://www.w3.org/TR/shacl/) schemas for:
   - Registry projects and dMRV form validation
-  - Methodology, credit class and credit vintage metadata validation (TODO)
+  - Methodology, credit class, project, credit vintage and retirement metadata validation
 
 ## SHACL Graphs
 

--- a/shacl/credit-class.ttl
+++ b/shacl/credit-class.ttl
@@ -10,7 +10,7 @@
 
 regen:CreditClassVersionShape
   a rdfs:Class, sh:NodeShape ;
-  sh:targetClass regen:CreditClassVersion ;
+  sh:targetClass regen:CreditClass ;
   rdfs:subClassOf rdfs:Resource ;
   sh:property [
     sh:path schema:url ;

--- a/shacl/credit-class.ttl
+++ b/shacl/credit-class.ttl
@@ -66,8 +66,8 @@ regen:CreditClassVersionShape
     sh:node dash:ListShape ;
     sh:property [
       sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-      sh:nodeKind sh:IRI ;
       sh:class regen:Indicator ;
+      sh:nodeKind sh:IRI ;
     ] ;
   ] ;
 .

--- a/shacl/credit-class.ttl
+++ b/shacl/credit-class.ttl
@@ -32,6 +32,44 @@ regen:CreditClassVersionShape
     sh:maxCount 1 ;
     sh:minCount 1 ;
   ] ;
+
+  # The following properties are based on https://app.mural.co/t/exploros/m/exploros/1626198876689/ecd285bfe106442917d13fb94421b33de7f5d981?sender=marie6396
+  # which is still WIP so subject to change.
+  sh:property [
+    sh:path regen:ecosystemType ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path regen:projectType ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path regen:indicator ;
+    sh:nodeKind sh:IRI ;
+    sh:class regen:Indicator ;
+  ] ;
+  sh:property [
+    sh:path regen:unit ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path regen:methods ;
+    sh:node dash:ListShape ;
+    sh:property [
+      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+      sh:class regen:Methodology ;
+      sh:nodeKind sh:IRI ;
+    ] ;
+  ] ;
+  sh:property [
+    sh:path regen:coBenefits ;
+    sh:node dash:ListShape ;
+    sh:property [
+      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+      sh:nodeKind sh:IRI ;
+      sh:class regen:Indicator ;
+    ] ;
+  ] ;
 .
 
 regen:StandardShape

--- a/shacl/credit-class.ttl
+++ b/shacl/credit-class.ttl
@@ -1,0 +1,59 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix regen: <http://regen.network/> .
+
+# regen:CreditClassVersionShape defines the metadata that goes
+# into the credit_class_version.metadata column in the Postgres database.
+
+regen:CreditClassVersionShape
+  a rdfs:Class, sh:NodeShape ;
+  sh:targetClass regen:CreditClassVersion ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:property [
+    sh:path schema:url ;
+    sh:datatype schema:URL ;
+  ] ;
+  sh:property [
+    sh:path regen:standard ;
+    sh:maxCount 1 ;
+    sh:minCount 1 ;
+    sh:node regen:StandardShape ;
+  ] ;
+  sh:property [
+    sh:path regen:offsetGenerationMethod ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path regen:creditDenom ;
+    sh:datatype xsd:string ;
+    sh:maxCount 1 ;
+    sh:minCount 1 ;
+  ] ;
+.
+
+regen:StandardShape
+  a rdfs:Class, sh:NodeShape ;
+  sh:property [
+    sh:path schema:name ;
+    sh:datatype xsd:string ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path schema:version ;
+    sh:datatype xsd:string ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path regen:documentId ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path schema:url ;
+    sh:datatype schema:URL ;
+  ] ;
+.

--- a/shacl/credit-vintage.ttl
+++ b/shacl/credit-vintage.ttl
@@ -1,0 +1,76 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix regen: <http://regen.network/> .
+
+# regen:CreditVintageShape defines generic metadata that goes
+# into the credit_vintage.metadata column in the Postgres database.
+# 
+# Note that credit_vintage.metadata could also store other kind of data
+# specific to its corresponding credit_class.
+
+regen:CreditVintageShape
+  a rdfs:Class, sh:NodeShape ;
+  sh:targetClass regen:CreditVintage ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:property [
+    sh:path regen:bufferDistribution ;
+    sh:node regen:BufferDistributionShape ;
+  ] ;
+  sh:property [
+    sh:path regen:additionalCertifications ;
+    sh:node dash:ListShape ;
+    sh:property [
+      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+      sh:datatype xsd:string ;
+    ] ;
+  ] ;
+  sh:property [
+    sh:path regen:serialNumber ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path regen:initialIssuanceTotalGrossAmount ;
+    sh:minExclusive 0;
+  ] ;
+.
+
+# regen:CreditVintageInitialDistributionShape defines a credit vintage initial distribution that is stored
+# into the credit_vintage.initial_distribution column in the Postgres database.
+
+regen:CreditVintageInitialDistributionShape
+  a rdfs:Class, sh:NodeShape ;
+  sh:targetClass regen:CreditVintage ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:property [
+    sh:path regen:projectDeveloperDistribution ;
+    sh:minInclusive 0;
+    sh:maxInclusive 1;
+  ] ;
+  sh:property [
+    sh:path regen:landStewardDistribution ;
+    sh:minInclusive 0;
+    sh:maxInclusive 1;
+  ] ;
+  sh:property [
+    sh:path regen:landOwnerDistribution ;
+    sh:minInclusive 0;
+    sh:maxInclusive 1;
+  ] ;
+.
+
+regen:BufferDistributionShape
+  a rdfs:Class, sh:NodeShape ;
+  sh:property [
+    sh:path regen:bufferPool ;
+    sh:minInclusive 0;
+    sh:maxInclusive 1;
+  ] ;
+  sh:property [
+    sh:path regen:permanenceReversalBuffer ;
+    sh:minInclusive 0;
+    sh:maxInclusive 1;
+  ] ;
+.

--- a/shacl/methodology.ttl
+++ b/shacl/methodology.ttl
@@ -10,7 +10,7 @@
 
 regen:MethodologyVersionShape
   a rdfs:Class, sh:NodeShape ;
-  sh:targetClass regen:MethodologyVersion ;
+  sh:targetClass regen:Methodology ;
   rdfs:subClassOf rdfs:Resource ;
   sh:property [
     sh:path schema:url ;

--- a/shacl/methodology.ttl
+++ b/shacl/methodology.ttl
@@ -1,0 +1,19 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix regen: <http://regen.network/> .
+
+# regen:MethodologyVersionShape defines the metadata that goes
+# into the methodology_version.metadata column in the Postgres database.
+
+regen:MethodologyVersionShape
+  a rdfs:Class, sh:NodeShape ;
+  sh:targetClass regen:MethodologyVersion ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:property [
+    sh:path schema:url ;
+    sh:datatype schema:URL ;
+  ] ;
+.

--- a/shacl/project.ttl
+++ b/shacl/project.ttl
@@ -1,0 +1,31 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix regen: <http://regen.network/> .
+
+# regen:ProjectShape defines generic metadata that goes
+# into the project.metadata column in the Postgres database.
+# 
+# Note that project.metadata can also store other kind of data
+# than is defined as part of other SHACL shapes (e.g. regen:ProjectPageShape).
+
+regen:ProjectShape
+  a rdfs:Class, sh:NodeShape ;
+  sh:targetClass regen:Project ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:property [
+    sh:path regen:additionalCertifications ;
+    sh:node dash:ListShape ;
+    sh:property [
+      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+      sh:node regen:StandardShape ;
+    ] ;
+  ] ;
+  sh:property [
+    sh:path regen:externalProjectUrl ;
+    sh:datatype schema:URL ;
+  ] ;
+.

--- a/shacl/project.ttl
+++ b/shacl/project.ttl
@@ -17,12 +17,8 @@ regen:ProjectShape
   sh:targetClass regen:Project ;
   rdfs:subClassOf rdfs:Resource ;
   sh:property [
-    sh:path regen:additionalCertifications ;
-    sh:node dash:ListShape ;
-    sh:property [
-      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-      sh:node regen:StandardShape ;
-    ] ;
+    sh:path regen:additionalCertification ;
+    sh:node regen:StandardShape ;
   ] ;
   sh:property [
     sh:path regen:externalProjectUrl ;

--- a/shacl/retirement.ttl
+++ b/shacl/retirement.ttl
@@ -1,0 +1,19 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix regen: <http://regen.network/> .
+
+# regen:RetirementShape defines the metadata that goes
+# into the retirement.metadata column in the Postgres database.
+
+regen:RetirementShape
+  a rdfs:Class, sh:NodeShape ;
+  sh:targetClass regen:Retirement ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:property [
+    sh:path schema:url ;
+    sh:datatype schema:URL ;
+  ] ;
+.


### PR DESCRIPTION
ref: regen-network/regen-registry#660

A follow-up issue will be about starting the ontology definition to define `regen:` properties: https://github.com/regen-network/regen-registry/issues/669

PR on registry-server: https://github.com/regen-network/registry-server/pull/87