### PR TITLE
refactor: update toucan URI to be optional

### DIFF
--- a/jsonld/C03/credit-batch-metadata/C03-batch-full-example.jsonld
+++ b/jsonld/C03/credit-batch-metadata/C03-batch-full-example.jsonld
@@ -3,5 +3,6 @@
     "regen": "http://regen.network/"
   },
   "@type": "regen:C03-CreditBatch",
-  "regen:toucanVintageTokenId": 123
+  "regen:toucanVintageTokenId": 123,
+  "regen:toucanURI": "http://toucan.earth/vintages/123"
 }

--- a/jsonld/C03/project-metadata/C03-project-minimal-example.jsonld
+++ b/jsonld/C03/project-metadata/C03-project-minimal-example.jsonld
@@ -10,7 +10,6 @@
   "regen:toucanProjectTokenId": 123,
   "schema:name": "VCS-123",
   "regen:vcsProjectId": 123,
-  "regen:toucanURI": "http://toucan.earth/projects/123",
   "regen:approvedMethodologies": [
     {
       "schema:name": "AMS-I.C.",

--- a/shacl/common.ttl
+++ b/shacl/common.ttl
@@ -4,7 +4,4 @@
 
 regen:ToucanURIPropertyShape sh:path regen:toucanURI ;
   sh:datatype xsd:string ;
-  sh:minCount 1 ;
-  sh:maxCount 1 ;
-  sh:minLength 1 ;
 .

--- a/shacl/common.ttl
+++ b/shacl/common.ttl
@@ -4,4 +4,6 @@
 
 regen:ToucanURIPropertyShape sh:path regen:toucanURI ;
   sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minLength 1 ;
 .


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

The toucan URI will most likely be empty when we are ready to launch. In Regen Ledger v5.0, we have implemented the ability to update the metadata for an open credit batch, so we will be able to populate it in the future, but all post requests from the bridge service will fail if we require the URI to be populated. This pull request updates the toucan URI to be optional.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] manually tested (if applicable)