### PR TITLE
feat: add support for optional credit class image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:bullseye
 RUN apt-get update -y && apt-get upgrade -yy
 RUN apt-get install -yy wget openjdk-11-jre python3
 WORKDIR /app

--- a/jsonld/credit-batches/C01-verified-carbon-standard-batch.jsonld
+++ b/jsonld/credit-batches/C01-verified-carbon-standard-batch.jsonld
@@ -4,6 +4,9 @@
     "regen": "https://schema.regen.network#",
     "regen:additionalCertifications": {
       "@container": "@list"
+    },
+    "schema:url": {
+      "@type": "schema:URL"
     }
   },
   "@type": "regen:C01-CreditBatch",
@@ -12,17 +15,11 @@
   "regen:additionalCertifications": [
     {
       "schema:name": "",
-      "schema:url": {
-        "@type": "schema:URL",
-        "@value": ""
-      }
+      "schema:url": ""
     },
     {
       "schema:name": "",
-      "schema:url": {
-        "@type": "schema:URL",
-        "@value": ""
-      }
+      "schema:url": ""
     }
   ]
 }

--- a/jsonld/credit-batches/C02-batch.jsonld
+++ b/jsonld/credit-batches/C02-batch.jsonld
@@ -28,9 +28,6 @@
   ],
   "regen:projectVerifier": {
     "schema:name": "",
-    "schema:url": {
-      "@type": "schema:URL",
-      "@value": ""
-    }
+    "schema:url": ""
   }
 }

--- a/jsonld/credit-classes/C01-verified-carbon-standard-class.jsonld
+++ b/jsonld/credit-classes/C01-verified-carbon-standard-class.jsonld
@@ -19,16 +19,10 @@
   "@type": "regen:CreditClass",
   "schema:description": "",
   "schema:name": "",
-  "schema:url": {
-    "@type": "schema:URL",
-    "@value": ""
-  },
+  "schema:url": "",
   "regen:sourceRegistry": {
     "schema:name": "",
-    "schema:url": {
-      "@type": "schema:URL",
-      "@value": ""
-    }
+    "schema:url": ""
   },
   "regen:sectoralScope": [
     ""

--- a/jsonld/credit-classes/C02-city-forest-credits-class.jsonld
+++ b/jsonld/credit-classes/C02-city-forest-credits-class.jsonld
@@ -25,29 +25,13 @@
   "@type": "regen:C02-CreditClass",
   "schema:name": "",
   "schema:description": "",
-  "schema:url": {
-    "@type": "schema:URL",
-    "@value": ""
-  },
+  "schema:url": "",
   "regen:sourceRegistry": {
     "schema:name": "",
-    "schema:url": {
-      "@type": "schema:URL",
-      "@value": ""
-    }
+    "schema:url": ""
   },
-  "regen:sectoralScope": [
-    {
-      "@type": "xsd:string",
-      "@value": ""
-    }
-  ],
-  "regen:offsetGenerationMethod": [
-    {
-      "@type": "xsd:string",
-      "@value": ""
-    }
-  ],
+  "regen:sectoralScope": [""],
+  "regen:offsetGenerationMethod": [""],
   "regen:approvedMethodologies": {
     "@type": "schema:ItemList",
     "schema:itemListElement": [
@@ -74,9 +58,6 @@
     ""
   ],
   "regen:carbonOffsetStandard": {
-    "schema:url": {
-      "@type": "schema:URL",
-      "@value": ""
-    }
+    "schema:url": ""
   }
 }

--- a/jsonld/credit-classes/credit-class.jsonld
+++ b/jsonld/credit-classes/credit-class.jsonld
@@ -58,6 +58,5 @@
   "regen:verificationMethod": "",
   "regen:projectActivities": [
     ""
-  ],
-  "regen:tokenizationSource": ""
+  ]
 }

--- a/jsonld/credit-classes/credit-class.jsonld
+++ b/jsonld/credit-classes/credit-class.jsonld
@@ -22,7 +22,7 @@
       "@type": "schema:URL"
     }
   },
-  "@type": ["regen:CXX-CreditClass", "regen:CreditClass"],
+  "@type": "regen:CreditClass",
   "schema:description": "",
   "schema:name": "",
   "schema:url": "",

--- a/jsonld/credit-classes/credit-class.jsonld
+++ b/jsonld/credit-classes/credit-class.jsonld
@@ -1,0 +1,63 @@
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "regen": "https://schema.regen.network#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "schema:itemListElement": {
+      "@container": "@list"
+    },
+    "regen:sectoralScope": {
+      "@container": "@list"
+    },
+    "regen:offsetGenerationMethod": {
+      "@container": "@list"
+    },
+    "regen:projectActivities": {
+      "@container": "@list"
+    },
+    "schema:url": {
+      "@type": "schema:URL"
+    },
+    "schema:image": {
+      "@type": "schema:URL"
+    }
+  },
+  "@type": ["regen:CXX-CreditClass", "regen:CreditClass"],
+  "schema:description": "",
+  "schema:name": "",
+  "schema:url": "",
+  "schema:image": "",
+  "regen:sourceRegistry": {
+    "schema:name": "",
+    "schema:url": ""
+  },
+  "regen:sectoralScope": [
+    ""
+  ],
+  "regen:offsetGenerationMethod": [
+    ""
+  ],
+  "regen:approvedMethodologies": {
+    "@type": "schema:ItemList",
+    "schema:itemListElement": [
+      {
+        "schema:name": "",
+        "schema:url": "",
+        "schema:identifier": "",
+        "schema:version": ""
+      },
+      {
+        "schema:name": "",
+        "schema:url": "",
+        "schema:identifier": "",
+        "schema:version": ""
+      }
+    ],
+    "schema:url": ""
+  },
+  "regen:verificationMethod": "",
+  "regen:projectActivities": [
+    ""
+  ],
+  "regen:tokenizationSource": ""
+}

--- a/ops/C01/credit-class-metadata/C01-verified-carbon-standard-credit-class.jsonld
+++ b/ops/C01/credit-class-metadata/C01-verified-carbon-standard-credit-class.jsonld
@@ -19,36 +19,18 @@
   "@type": "regen:C01-CreditClass",
   "schema:name": "Verified Carbon Standard",
   "schema:description": "This credit class provides a vehicle for nature based Verified Carbon Units (VCUs) to enter the blockchain space via issuance on Regen Ledger. It can be used by project developers, credit brokers, and other stakeholders interested in digitizing carbon credits issued by the VCS program to make them available in the emerging world of decentralized finance.",
-  "schema:url": {
-    "@type": "schema:URL",
-    "@value": "https://library.regen.network/v/regen-registry-credit-classes/credits-from-other-registries/verified-carbon-standard-credit-class"
-  },
+  "schema:url": "https://library.regen.network/v/regen-registry-credit-classes/credits-from-other-registries/verified-carbon-standard-credit-class",
   "regen:sourceRegistry": {
     "schema:name": "Verra",
-    "schema:url": {
-      "@type": "schema:URL",
-      "@value": "https://verra.org/"
-    }
+    "schema:url": "https://verra.org/"
   },
   "regen:sectoralScope": [
-    {
-      "@type": "xsd:string",
-      "@value": "Agriculture Forestry and Other Land Use (AFOLU)"
-    },
-    {
-      "@type": "xsd:string",
-      "@value": "Livestock and Manure Management"
-    }
+    "Agriculture Forestry and Other Land Use (AFOLU)",
+    "Livestock and Manure Management"
   ],
   "regen:offsetGenerationMethod": [
-    {
-      "@type": "xsd:string",
-      "@value": "Emission Reductions"
-    },
-    {
-      "@type": "xsd:string",
-      "@value": "Carbon Removals"
-    }
+    "Emission Reductions",
+    "Carbon Removals"
   ],
   "regen:approvedMethodologies": {
     "@type": "schema:ItemList",

--- a/ops/C02/credit-class-metadata/C02-city-forest-credits-credit-class.jsonld
+++ b/ops/C02/credit-class-metadata/C02-city-forest-credits-credit-class.jsonld
@@ -25,29 +25,13 @@
   "@type": "regen:C02-CreditClass",
   "schema:name": "Urban Forest Carbon Credit Class",
   "schema:description": "City Forest Credits is the national standard for greenhouse gas emission reduction and removal for tree projects in cities and towns. Developed by leading scientists, industry, and urban forest professionals, the Standard and Protocols define the set of rules and requirements that tree preservation projects must follow in order to earn third-party verified carbon credits.\n\nCFC has a 40-year and a 100-year Tree Preservation Protocol, modeled after avoided conversion or avoided emissions protocols in forestry. The 40-year Protocol was designed for the voluntary market and the 100-year Protocol for the compliance market in the state of California.",
-  "schema:url": {
-    "@type": "schema:URL",
-    "@value": "https://www.cityforestcredits.org/"
-  },
+  "schema:url": "https://www.cityforestcredits.org/",
   "regen:sourceRegistry": {
     "schema:name": "City Forest Credits",
-    "schema:url": {
-      "@type": "schema:URL",
-      "@value": "https://www.cityforestcredits.org/"
-    }
+    "schema:url": "https://www.cityforestcredits.org/"
   },
-  "regen:sectoralScope": [
-    {
-      "@type": "xsd:string",
-      "@value": "Agriculture Forestry and Other Land Use (AFOLU)"
-    }
-  ],
-  "regen:offsetGenerationMethod": [
-    {
-      "@type": "xsd:string",
-      "@value": "Avoided Emissions"
-    }
-  ],
+  "regen:sectoralScope": ["Agriculture Forestry and Other Land Use (AFOLU)"],
+  "regen:offsetGenerationMethod": ["Avoided Emissions"],
   "regen:approvedMethodologies": {
     "@type": "schema:ItemList",
     "schema:itemListElement": [
@@ -75,9 +59,6 @@
   ],
   "regen:carbonOffsetStandard": {
     "schema:name": "City Forest Credits Standard",
-    "schema:url": {
-      "@type": "schema:URL",
-      "@value": "https://www.cityforestcredits.org/wp-content/uploads/2022/03/City-Forest-Credits-Standard-V2.pdf"
-    }
+    "schema:url": "https://www.cityforestcredits.org/wp-content/uploads/2022/03/City-Forest-Credits-Standard-V2.pdf"
   }
 }

--- a/shacl/common.ttl
+++ b/shacl/common.ttl
@@ -3,6 +3,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
 
 regen:ToucanURIPropertyShape sh:path regen:toucanURI ;
   sh:datatype xsd:string ;

--- a/shacl/common.ttl
+++ b/shacl/common.ttl
@@ -41,3 +41,24 @@ regen:ProjectActivitiesPropertyShape sh:path regen:projectActivities ;
   sh:minCount 1 ;
   sh:maxCount 1 ;
 .
+
+regen:ApprovedMethodologiesPropertyShape sh:path regen:approvedMethodologies ;
+  sh:class schema:ItemList ;
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+  sh:property [
+    sh:path schema:itemListElement ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:property [
+      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+      sh:node regen:MethodologyVersionShape ;
+      sh:minCount 1 ;
+    ] ;
+  ] ;
+  sh:property [
+    sh:path schema:url ;
+    sh:maxCount 1 ;
+    sh:datatype schema:URL ;
+  ] ;
+.

--- a/shacl/credit-classes/C01-verified-carbon-standard-class.ttl
+++ b/shacl/credit-classes/C01-verified-carbon-standard-class.ttl
@@ -4,6 +4,9 @@
 @prefix regen: <https://schema.regen.network#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+regen:C01-CreditClass rdfs:subClassOf regen:CreditClass .
 
 regen:C01-CreditClassShape a sh:NodeShape ;
   sh:targetClass regen:C01-CreditClass ;

--- a/shacl/credit-classes/C01-verified-carbon-standard-class.ttl
+++ b/shacl/credit-classes/C01-verified-carbon-standard-class.ttl
@@ -1,9 +1,5 @@
-@prefix schema: <http://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix regen: <https://schema.regen.network#> .
-@prefix dash: <http://datashapes.org/dash#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 regen:C01-CreditClass rdfs:subClassOf regen:CreditClass .

--- a/shacl/credit-classes/C01-verified-carbon-standard-class.ttl
+++ b/shacl/credit-classes/C01-verified-carbon-standard-class.ttl
@@ -10,46 +10,4 @@ regen:C01-CreditClass rdfs:subClassOf regen:CreditClass .
 
 regen:C01-CreditClassShape a sh:NodeShape ;
   sh:targetClass regen:C01-CreditClass ;
-  sh:property [
-    sh:path schema:description ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:minLength 1 ;
-    sh:datatype xsd:string ;
-  ] ;
-  sh:property [
-    sh:path schema:name ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:minLength 1 ;
-    sh:datatype xsd:string ;
-  ] ;
-  sh:property [
-    sh:path schema:url ;
-    sh:datatype schema:URL ;
-  ] ;
-  sh:property [
-    sh:path regen:sourceRegistry ;
-    sh:node regen:NameUrlShape ;
-  ] ;
-  sh:property [
-    sh:path regen:sectoralScope ;
-    sh:node dash:ListShape ;
-    sh:property [
-      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-      sh:datatype xsd:string ;
-      sh:minLength 1 ;
-    ] ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-  ] ;
-  sh:property regen:OffsetGenerationMethodPropertyShape ; 
-  sh:property regen:ApprovedMethodologiesPropertyShape ;
-  sh:property [
-    sh:path regen:verificationMethod ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:minLength 1 ;
-    sh:datatype xsd:string ;
-  ] ;
 .

--- a/shacl/credit-classes/C02-city-forest-credits-class.ttl
+++ b/shacl/credit-classes/C02-city-forest-credits-class.ttl
@@ -4,6 +4,9 @@
 @prefix regen: <https://schema.regen.network#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+regen:C02-CreditClass rdfs:subClassOf regen:CreditClass .
 
 regen:C02-CreditClassShape a sh:NodeShape ;
   sh:targetClass regen:C02-CreditClass ;

--- a/shacl/credit-classes/C02-city-forest-credits-class.ttl
+++ b/shacl/credit-classes/C02-city-forest-credits-class.ttl
@@ -10,58 +10,6 @@ regen:C02-CreditClass rdfs:subClassOf regen:CreditClass .
 
 regen:C02-CreditClassShape a sh:NodeShape ;
   sh:targetClass regen:C02-CreditClass ;
-  sh:property [
-    sh:path schema:description ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:minLength 1 ;
-    sh:datatype xsd:string ;
-  ] ;
-  sh:property [
-    sh:path schema:name ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:minLength 1 ;
-    sh:datatype xsd:string ;
-  ] ;
-  sh:property [
-    sh:path schema:url ;
-    sh:datatype schema:URL ;
-  ] ;
-  sh:property [
-    sh:path regen:sourceRegistry ;
-    sh:node regen:NameUrlShape ;
-  ] ;
-  sh:property [
-    sh:path regen:sectoralScope ;
-    sh:node dash:ListShape ;
-    sh:property [
-      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-      sh:datatype xsd:string ;
-      sh:minLength 1 ;
-    ] ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-  ] ;
-  sh:property [
-    sh:path regen:offsetGenerationMethod ;
-    sh:node dash:ListShape ;
-    sh:property [
-      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-      sh:datatype xsd:string ;
-      sh:minLength 1 ;
-    ] ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-  ] ;
-  sh:property regen:ApprovedMethodologiesPropertyShape ;
-  sh:property [
-    sh:path regen:verificationMethod ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:minLength 1 ;
-    sh:datatype xsd:string ;
-  ] ;
   sh:property regen:ProjectActivitiesPropertyShape;
   sh:property [
     sh:path regen:carbonOffsetStandard ;

--- a/shacl/credit-classes/C03-toucan-tco2-class.ttl
+++ b/shacl/credit-classes/C03-toucan-tco2-class.ttl
@@ -11,58 +11,6 @@ regen:C03-CreditClass rdfs:subClassOf regen:CreditClass .
 regen:C03-CreditClassShape a sh:NodeShape ;
   sh:targetClass regen:C03-CreditClass ;
   sh:property [
-    sh:path schema:description ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:minLength 1 ;
-    sh:datatype xsd:string ;
-  ] ;
-  sh:property [
-    sh:path schema:name ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:minLength 1 ;
-    sh:datatype xsd:string ;
-  ] ;
-  sh:property [
-    sh:path schema:url ;
-    sh:datatype schema:URL ;
-  ] ;
-  sh:property [
-    sh:path regen:sourceRegistry ;
-    sh:node regen:NameUrlShape ;
-  ] ;
-  sh:property [
-    sh:path regen:sectoralScope ;
-    sh:node dash:ListShape ;
-    sh:property [
-      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-      sh:datatype xsd:string ;
-      sh:minLength 1 ;
-    ] ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-  ] ;
-  sh:property [
-    sh:path regen:offsetGenerationMethod ;
-    sh:node dash:ListShape ;
-    sh:property [
-      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-      sh:datatype xsd:string ;
-      sh:minLength 1 ;
-    ] ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-  ] ;
-  sh:property regen:ApprovedMethodologiesPropertyShape ;
-  sh:property [
-    sh:path regen:verificationMethod ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:minLength 1 ;
-    sh:datatype xsd:string ;
-  ] ;
-  sh:property [
     sh:path regen:tokenizationSource ;
     sh:minCount 1 ;
     sh:maxCount 1 ;

--- a/shacl/credit-classes/C03-toucan-tco2-class.ttl
+++ b/shacl/credit-classes/C03-toucan-tco2-class.ttl
@@ -4,6 +4,9 @@
 @prefix regen: <https://schema.regen.network#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+regen:C03-CreditClass rdfs:subClassOf regen:CreditClass .
 
 regen:C03-CreditClassShape a sh:NodeShape ;
   sh:targetClass regen:C03-CreditClass ;

--- a/shacl/credit-classes/credit-class.ttl
+++ b/shacl/credit-classes/credit-class.ttl
@@ -9,7 +9,49 @@
 regen:CreditClassShape a sh:NodeShape ;
   sh:targetClass regen:CreditClass ;
   sh:property [
+    sh:path schema:name ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:minLength 1 ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path schema:description ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:minLength 1 ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path schema:url ;
+    sh:datatype schema:URL ;
+  ] ;
+  sh:property [
     sh:path schema:image ;
     sh:datatype schema:URL ;
   ] ;
+  sh:property [
+    sh:path regen:sourceRegistry ;
+    sh:node regen:NameUrlShape ;
+  ] ;
+  sh:property [
+    sh:path regen:sectoralScope ;
+    sh:node dash:ListShape ;
+    sh:property [
+      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+      sh:datatype xsd:string ;
+      sh:minLength 1 ;
+    ] ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property regen:OffsetGenerationMethodPropertyShape ;
+  sh:property [
+    sh:path regen:verificationMethod ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:minLength 1 ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property regen:ApprovedMethodologiesPropertyShape ;
 .

--- a/shacl/credit-classes/credit-class.ttl
+++ b/shacl/credit-classes/credit-class.ttl
@@ -1,77 +1,15 @@
-@prefix dash: <http://datashapes.org/dash#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <http://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix regen: <https://schema.regen.network#> .
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-# regen:CreditClassVersionShape defines the metadata that goes
-# into the credit_class_version.metadata column in the Postgres database.
-
-regen:CreditClassVersionShape
-  a rdfs:Class, sh:NodeShape ;
+regen:CreditClassShape a sh:NodeShape ;
   sh:targetClass regen:CreditClass ;
-  rdfs:subClassOf rdfs:Resource ;
   sh:property [
-    sh:path schema:url ;
+    sh:path schema:image ;
     sh:datatype schema:URL ;
-  ] ;
-  sh:property [
-    sh:path regen:offsetGenerationMethod ;
-    sh:datatype xsd:string ;
-  ] ;
-  sh:property [
-    sh:path regen:creditDenom ;
-    sh:datatype xsd:string ;
-    sh:maxCount 1 ;
-    sh:minCount 1 ;
-  ] ;
-  sh:property [
-    sh:path regen:SDGs ;
-    sh:node dash:ListShape ;
-    sh:property [
-      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-      sh:nodeKind sh:IRI ;
-      sh:class regen:SDG ;
-    ] ;
-  ] ;
-
-  # The following properties are based on https://app.mural.co/t/exploros/m/exploros/1626198876689/ecd285bfe106442917d13fb94421b33de7f5d981?sender=marie6396
-  # which is still WIP so subject to change.
-  sh:property [
-    sh:path regen:ecosystemType ;
-    sh:datatype xsd:string ;
-  ] ;
-  sh:property [
-    sh:path regen:projectType ;
-    sh:datatype xsd:string ;
-  ] ;
-  sh:property [
-    sh:path regen:indicator ;
-    sh:nodeKind sh:IRI ;
-    sh:class regen:Indicator ;
-  ] ;
-  sh:property [
-    sh:path regen:unit ;
-    sh:datatype xsd:string ;
-  ] ;
-  sh:property [
-    sh:path regen:methods ;
-    sh:node dash:ListShape ;
-    sh:property [
-      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-      sh:class regen:Methodology ;
-      sh:nodeKind sh:IRI ;
-    ] ;
-  ] ;
-  sh:property [
-    sh:path regen:coBenefits ;
-    sh:node dash:ListShape ;
-    sh:property [
-      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-      sh:class regen:Indicator ;
-      sh:nodeKind sh:IRI ;
-    ] ;
   ] ;
 .

--- a/shacl/credit-classes/credit-class.ttl.legacy
+++ b/shacl/credit-classes/credit-class.ttl.legacy
@@ -1,0 +1,77 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix regen: <https://schema.regen.network#> .
+
+# regen:CreditClassVersionShape defines the metadata that goes
+# into the credit_class_version.metadata column in the Postgres database.
+
+regen:CreditClassVersionShape
+  a rdfs:Class, sh:NodeShape ;
+  sh:targetClass regen:CreditClass ;
+  rdfs:subClassOf rdfs:Resource ;
+  sh:property [
+    sh:path schema:url ;
+    sh:datatype schema:URL ;
+  ] ;
+  sh:property [
+    sh:path regen:offsetGenerationMethod ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path regen:creditDenom ;
+    sh:datatype xsd:string ;
+    sh:maxCount 1 ;
+    sh:minCount 1 ;
+  ] ;
+  sh:property [
+    sh:path regen:SDGs ;
+    sh:node dash:ListShape ;
+    sh:property [
+      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+      sh:nodeKind sh:IRI ;
+      sh:class regen:SDG ;
+    ] ;
+  ] ;
+
+  # The following properties are based on https://app.mural.co/t/exploros/m/exploros/1626198876689/ecd285bfe106442917d13fb94421b33de7f5d981?sender=marie6396
+  # which is still WIP so subject to change.
+  sh:property [
+    sh:path regen:ecosystemType ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path regen:projectType ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path regen:indicator ;
+    sh:nodeKind sh:IRI ;
+    sh:class regen:Indicator ;
+  ] ;
+  sh:property [
+    sh:path regen:unit ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path regen:methods ;
+    sh:node dash:ListShape ;
+    sh:property [
+      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+      sh:class regen:Methodology ;
+      sh:nodeKind sh:IRI ;
+    ] ;
+  ] ;
+  sh:property [
+    sh:path regen:coBenefits ;
+    sh:node dash:ListShape ;
+    sh:property [
+      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+      sh:class regen:Indicator ;
+      sh:nodeKind sh:IRI ;
+    ] ;
+  ] ;
+.

--- a/shacl/methodologies/methodology.ttl
+++ b/shacl/methodologies/methodology.ttl
@@ -31,23 +31,3 @@ regen:MethodologyVersionShape a sh:NodeShape ;
   ] ;
 .
 
-regen:ApprovedMethodologiesPropertyShape sh:path regen:approvedMethodologies ;
-  sh:class schema:ItemList ;
-  sh:minCount 1 ;
-  sh:maxCount 1 ;
-  sh:property [
-    sh:path schema:itemListElement ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:property [
-      sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-      sh:node regen:MethodologyVersionShape ;
-      sh:minCount 1 ;
-    ] ;
-  ] ;
-  sh:property [
-    sh:path schema:url ;
-    sh:maxCount 1 ;
-    sh:datatype schema:URL ;
-  ] ;
-.


### PR DESCRIPTION
## Description
ref: regen-network/regen-registry#1428

It also removes some unnecessary `@types`s : https://github.com/regen-network/regen-registry-standards/pull/56/commits/2872e5e755f1113615efbdcdc40890f9cec1c4b0
The impacted metadata also got updated on the prod database (their IRIs remaining the same since those changes are only format related changes and don't have any impact on the resulting canonized data)

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] reviewed documentation is accurate
- [ ] manually tested (if applicable)